### PR TITLE
Broaden default Solidity version to `>=0.5.0 <0.8.0` (and centralize defaulting logic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Options:
 
 ```console
 <name>
-  Name of generated interface
+  Name of generated interface. Default: MyInterface
 
 --validate
   Validate JSON before starting
 
 -V --solidity-version
-  Version of Solidity (for pragma)
+  Version of Solidity (for pragma). Default: >=0.5.0 <0.8.0
 
 -L --license
   SPDX license identifier. default: UNLICENSED

--- a/bin/abi-to-sol.ts
+++ b/bin/abi-to-sol.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
+const neodoc = require("neodoc");
 import {Abi as SchemaAbi} from "@truffle/contract-schema/spec";
 import * as abiSchema from "@truffle/contract-schema/spec/abi.spec.json";
 import betterAjvErrors from "better-ajv-errors";
 import Ajv from "ajv";
 
 import {generateSolidity} from "../lib";
-const neodoc = require("neodoc");
+import * as defaults from "../lib/defaults";
 
 const usage = `
 abi-to-sol
@@ -22,16 +23,16 @@ Usage:
 
 Options:
   <name>
-    Name of generated interface
+    Name of generated interface. Default: ${defaults.name}
 
   --validate
     Validate JSON before starting
 
   -V --solidity-version
-    Version of Solidity (for pragma)
+    Version of Solidity (for pragma). Default: ${defaults.solidityVersion}
 
   -L --license
-    SPDX license identifier. default: UNLICENSED
+    SPDX license identifier. Default: ${defaults.license}
 
   -h --help     Show this screen.
   --version     Show version.
@@ -66,9 +67,9 @@ const main = async () => {
   const validate = ajv.compile(abiSchema);
 
   const options = {
-    solidityVersion: args["-V"] || args["--solidity-version"] || "^0.7.0",
-    name: args["<name>"] || "MyInterface",
-    license: args["-L"] || args["--license"] || "UNLICENSED",
+    solidityVersion: args["-V"] || args["--solidity-version"],
+    name: args["<name>"],
+    license: args["-L"] || args["--license"],
     validate: args["--validate"] || false,
   };
 

--- a/lib/defaults.ts
+++ b/lib/defaults.ts
@@ -1,0 +1,3 @@
+export const name = "MyInterface";
+export const license = "UNLICENSED";
+export const solidityVersion = ">=0.5.0 <0.8.0";

--- a/lib/solidity.ts
+++ b/lib/solidity.ts
@@ -16,6 +16,8 @@ import {
 
 import {Visitor, VisitOptions, dispatch} from "./visitor";
 
+import * as defaults from "./defaults";
+
 import {
   Component,
   Declaration,
@@ -25,7 +27,7 @@ import {
 
 export interface GenerateSolidityOptions {
   abi: Abi | SchemaAbi;
-  name: string;
+  name?: string;
   solidityVersion?: string;
   license?: string;
 }
@@ -75,9 +77,9 @@ class SolidityGenerator implements Visitor<string, Context> {
 
   constructor({
     declarations,
-    name,
-    license = "UNLICENSED",
-    solidityVersion = ">=0.5.0 <0.8.0",
+    name = defaults.name,
+    license = defaults.license,
+    solidityVersion = defaults.solidityVersion,
   }: ConstructorOptions) {
     this.name = name;
     this.license = license;


### PR DESCRIPTION
Change default Solidity version from `^0.7.0` to `>=0.5.0 <0.8.0`

- Add `lib/defaults` as central home for defaults
- Apply these defaults in only one place (in lib/solidity)
- Remove the defaulting logic from bin/abi-to-sol
- Interpolate these values in usage help string (instead of hardcoded)