### PR TITLE
Begin to differ output based on Solidity version / features used by ABI

### DIFF
--- a/packages/abi-to-sol/lib/abi-features.ts
+++ b/packages/abi-to-sol/lib/abi-features.ts
@@ -1,0 +1,64 @@
+import { Abi as SchemaAbi } from "@truffle/contract-schema/spec";
+import * as Codec from "@truffle/codec";
+import * as Abi from "@truffle/abi-utils";
+
+import { Visitor, VisitOptions, dispatch, Node } from "./visitor";
+
+export const allFeatures = ["defines-receive", "defines-fallback"] as const;
+
+export type AbiFeature = typeof allFeatures[number];
+export type AbiFeatures = Set<AbiFeature>;
+
+export const collectAbiFeatures = (node: SchemaAbi | Node) =>
+  dispatch({
+    node,
+    visitor: new AbiFeaturesCollector(),
+  });
+
+export class AbiFeaturesCollector implements Visitor<AbiFeatures> {
+  visitAbi({ node: nodes }: VisitOptions<Abi.Abi>): AbiFeatures {
+    return nodes
+      .map((node) => dispatch({ node, visitor: this }))
+      .reduce((a, b) => new Set([...a, ...b]), new Set<AbiFeature>());
+  }
+
+  visitEventEntry({ node: entry }: VisitOptions<Abi.EventEntry>): AbiFeatures {
+    return entry.inputs
+      .map((node) => dispatch({ node, visitor: this }))
+      .reduce((a, b) => new Set([...a, ...b]), new Set<AbiFeature>());
+  }
+
+  visitFunctionEntry({
+    node: entry,
+  }: VisitOptions<Abi.FunctionEntry>): AbiFeatures {
+    return [...entry.inputs, ...(entry.outputs || [])]
+      .map((node) => dispatch({ node, visitor: this }))
+      .reduce((a, b) => new Set([...a, ...b]), new Set<AbiFeature>());
+  }
+
+  visitConstructorEntry({
+    node: entry,
+  }: VisitOptions<Abi.ConstructorEntry>): AbiFeatures {
+    return entry.inputs
+      .map((node) => dispatch({ node, visitor: this }))
+      .reduce((a, b) => new Set([...a, ...b]), new Set<AbiFeature>());
+  }
+
+  visitFallbackEntry({
+    node: entry,
+  }: VisitOptions<Abi.FallbackEntry>): AbiFeatures {
+    return new Set(["defines-fallback"]);
+  }
+
+  visitReceiveEntry({
+    node: entry,
+  }: VisitOptions<Abi.ReceiveEntry>): AbiFeatures {
+    return new Set(["defines-receive"]);
+  }
+
+  visitParameter({
+    node: parameter,
+  }: VisitOptions<Abi.Parameter>): AbiFeatures {
+    return new Set();
+  }
+}

--- a/packages/abi-to-sol/lib/defaults.ts
+++ b/packages/abi-to-sol/lib/defaults.ts
@@ -1,4 +1,4 @@
 export const name = "MyInterface";
 export const license = "UNLICENSED";
-export const solidityVersion = ">=0.5.0 <0.8.0";
+export const solidityVersion = ">=0.5.0 <0.9.0";
 export const prettifyOutput = true;

--- a/packages/abi-to-sol/lib/index.ts
+++ b/packages/abi-to-sol/lib/index.ts
@@ -1,3 +1,4 @@
 import "source-map-support/register";
 
+export * as defaults from "./defaults";
 export {GenerateSolidityOptions, generateSolidity} from "./solidity";

--- a/packages/abi-to-sol/lib/version-features.ts
+++ b/packages/abi-to-sol/lib/version-features.ts
@@ -1,0 +1,32 @@
+import * as semver from "semver";
+
+export const allFeatures = [
+  {
+    name: "separate-receive-function",
+    range: ">=0.6.0",
+  },
+  {
+    name: "use-fallback-keyword",
+    range: ">=0.6.0",
+  },
+  {
+    name: "memory-array-parameters",
+    range: ">=0.7.0",
+  },
+  {
+    name: "calldata-array-parameters",
+    range: "^0.5.0 || ^0.6.0",
+  },
+] as const;
+
+export type VersionFeature = typeof allFeatures[number]["name"];
+export type VersionFeatures = Set<VersionFeature>;
+
+export const featuresForVersion = (
+  solidityVersion: string
+): VersionFeatures => {
+  const featureNames = allFeatures
+    .filter(({ range }) => semver.subset(solidityVersion, range))
+    .map(({ name }) => name);
+  return new Set(featureNames);
+};

--- a/packages/abi-to-sol/package.json
+++ b/packages/abi-to-sol/package.json
@@ -31,6 +31,7 @@
     "@types/jest": "^26.0.14",
     "@types/jest-json-schema": "^2.1.2",
     "@types/prettier": "^2.1.1",
+    "@types/semver": "^7.3.7",
     "change-case": "^4.1.1",
     "faker": "^5.1.0",
     "fast-check": "^2.4.0",
@@ -51,6 +52,7 @@
     "ajv": "^6.12.5",
     "better-ajv-errors": "^0.6.7",
     "neodoc": "^2.0.2",
+    "semver": "^7.3.5",
     "source-map-support": "^0.5.19"
   },
   "optionalDependencies": {

--- a/packages/web-ui/src/solidity/OptionsControls.tsx
+++ b/packages/web-ui/src/solidity/OptionsControls.tsx
@@ -13,6 +13,7 @@ import { InfoIcon } from "@chakra-ui/icons";
 import * as Options from "./Options";
 import * as Examples from "../abi/Examples";
 import { examples } from "../abi/Examples";
+import { defaults } from "abi-to-sol";
 
 
 export const OptionsControls = () => {
@@ -56,7 +57,7 @@ export const OptionsControls = () => {
         <Select
           id="version"
           value={options.solidityVersion || ""}
-          placeholder="Choose version"
+          placeholder={defaults.solidityVersion}
           onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
             setSolidityVersion(event.target.value)
           }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3503,6 +3503,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/semver@^7.3.7":
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.7.tgz#b9eb89d7dfa70d5d1ce525bc1411a35347f533a3"
+  integrity sha512-4g1jrL98mdOIwSOUh6LTlB0Cs9I0dQPwINUhBg7C6pN4HLr8GS8xsksJxilW6S6dQHVi2K/o+lQuQcg7LroCnw==
+
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"


### PR DESCRIPTION
(Currently still incomplete)

- Distinguish memory vs. calldata for array arguments
- Handle receive/fallback syntax history