### PR TITLE
Error upon Solidity version syntax ambiguity

### DIFF
--- a/packages/abi-to-sol/lib/version-features.ts
+++ b/packages/abi-to-sol/lib/version-features.ts
@@ -1,32 +1,62 @@
 import * as semver from "semver";
 
-export const allFeatures = [
-  {
-    name: "separate-receive-function",
-    range: ">=0.6.0",
-  },
-  {
-    name: "use-fallback-keyword",
-    range: ">=0.6.0",
-  },
-  {
-    name: "memory-array-parameters",
-    range: ">=0.7.0",
-  },
-  {
-    name: "calldata-array-parameters",
-    range: "^0.5.0 || ^0.6.0",
-  },
-] as const;
+export const mixed: unique symbol = Symbol();
 
-export type VersionFeature = typeof allFeatures[number]["name"];
-export type VersionFeatures = Set<VersionFeature>;
+export const allFeatures = {
+  "receive-keyword": {
+    ">=0.6.0": true,
+    "<0.6.0": false
+  },
+  "fallback-keyword": {
+    ">=0.6.0": true,
+    "<0.6.0": false
+  },
+  "array-parameter-location": {
+    ">=0.7.0": "memory",
+    "^0.5.0 || ^0.6.0": "calldata",
+    "<0.5.0": undefined
+  }
+} as const;
 
-export const featuresForVersion = (
-  solidityVersion: string
-): VersionFeatures => {
-  const featureNames = allFeatures
-    .filter(({ range }) => semver.subset(solidityVersion, range))
-    .map(({ name }) => name);
-  return new Set(featureNames);
+type AllFeatures = typeof allFeatures;
+
+export type Category = keyof AllFeatures;
+
+export type CategoryOptions<C extends Category = Category> = AllFeatures[C];
+
+export type CategoryOptionRange<C extends Category = Category> = string & {
+  [K in C]: keyof CategoryOptions<K>
+}[C];
+
+export type CategoryOption<C extends Category = Category> = {
+  [K in C]: CategoryOptions<K>[CategoryOptionRange<K>]
+}[C];
+
+export type VersionFeatures = {
+  [C in Category]: VersionFeature<C>;
 };
+
+export type VersionFeature<C extends Category> =
+  CategoryOption<C> | typeof mixed;
+
+export const forRange = (range: string | semver.Range): VersionFeatures => {
+  const forCategory = <C extends Category>(
+    category: C
+  ): VersionFeature<C> => {
+    const options = allFeatures[category];
+    const matchingRanges: CategoryOptionRange<C>[] =
+      (Object.keys(options) as CategoryOptionRange<C>[])
+        .filter(optionRange => semver.intersects(range, optionRange));
+
+    if (matchingRanges.length > 1) {
+      return mixed;
+    }
+
+    const [matchingRange] = matchingRanges;
+    return options[matchingRange];
+  }
+
+  return (Object.keys(allFeatures) as Category[])
+    .map(<C extends Category>(category: C) => ({ [category]: forCategory(category) }))
+    .reduce((a, b) => ({ ...a, ...b }), {}) as VersionFeatures;
+}


### PR DESCRIPTION
- Throw error when the input ABI uses features whose syntax differs across possible Solidity versions in the desired `-V` range

- Rewrite version-features as something of a key-value pair, where keys are version feature "categories" and values are "options".

- Break up possible options by slices of the complete interval of versions

- Aggregate this into `forRange` function that returns a map from each category to either a unique symbol `mixed` (for non-unique categories) or to the unambiguous category option for that range.

- Update Solidity generation to error when it needs to output some syntax that it cannot unambiguously generate for desired range.