### PR TITLE
Support custom ABI errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # abi-to-sol changelog
 
-## v0.4.1 (unreleased)
+## v0.5.0 (unreleased)
+
+### New features
+
+- Support custom ABI errors ([#33](https://github.com/gnidan/abi-to-sol/pull/33)
+  by [@gnidan](https://github.com/gnidan))
 
 ### Fixes
 

--- a/packages/abi-to-sol/package.json
+++ b/packages/abi-to-sol/package.json
@@ -40,7 +40,7 @@
     "jest-fast-check": "^0.0.1",
     "jest-json-schema": "^2.1.0",
     "lint-staged": ">=10",
-    "solc": "^0.7.2",
+    "solc": "^0.8.6",
     "ts-jest": "^26.4.0",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.3"

--- a/packages/abi-to-sol/src/abi-features.ts
+++ b/packages/abi-to-sol/src/abi-features.ts
@@ -8,6 +8,7 @@ export const allFeatures = [
   "defines-receive",
   "defines-fallback",
   "needs-abiencoder-v2",
+  "defines-error",
 ] as const;
 
 export type AbiFeature = typeof allFeatures[number];
@@ -29,6 +30,12 @@ export class AbiFeaturesCollector implements Visitor<AbiFeatures> {
   }
 
   visitEventEntry({ node: entry }: VisitOptions<Abi.EventEntry>): AbiFeatures {
+    return entry.inputs
+      .map((node) => dispatch({ node, visitor: this }))
+      .reduce((a, b) => ({ ...a, ...b }), {});
+  }
+
+  visitErrorEntry({ node: entry }: VisitOptions<Abi.ErrorEntry>): AbiFeatures {
     return entry.inputs
       .map((node) => dispatch({ node, visitor: this }))
       .reduce((a, b) => ({ ...a, ...b }), {});

--- a/packages/abi-to-sol/src/declarations.ts
+++ b/packages/abi-to-sol/src/declarations.ts
@@ -37,6 +37,12 @@ export class DeclarationsCollector implements Visitor<Declarations> {
       .reduce(mergeDeclarations, emptyDeclarations());
   }
 
+  visitErrorEntry({node: entry}: VisitOptions<Abi.ErrorEntry>): Declarations {
+    return entry.inputs
+      .map((node) => dispatch({node, visitor: this}))
+      .reduce(mergeDeclarations, emptyDeclarations());
+  }
+
   visitFunctionEntry({
     node: entry,
   }: VisitOptions<Abi.FunctionEntry>): Declarations {

--- a/packages/abi-to-sol/src/solidity.test.ts
+++ b/packages/abi-to-sol/src/solidity.test.ts
@@ -30,9 +30,6 @@ describe("generateSolidity", () => {
     fc.pre(
       abi.every((entry) => "type" in entry && entry.type !== "constructor")
     );
-    fc.pre(
-      abi.every((entry) => "type" in entry && entry.type !== "error")
-    );
     fc.pre(excludesFunctionParameters(abi));
 
     fc.pre(abi.length > 0);
@@ -40,7 +37,7 @@ describe("generateSolidity", () => {
     const output = generateSolidity({
       name: "MyInterface",
       abi,
-      solidityVersion: "^0.7.0",
+      solidityVersion: "^0.8.4",
     });
 
     let resultAbi;
@@ -68,7 +65,7 @@ describe("generateSolidity", () => {
     const output = generateSolidity({
       name: "Example",
       abi: abiWithoutConstructor,
-      solidityVersion: "^0.7.0",
+      solidityVersion: "^0.8.4",
     });
 
     it("generates output", () => {

--- a/packages/abi-to-sol/src/solidity.ts
+++ b/packages/abi-to-sol/src/solidity.ts
@@ -237,7 +237,7 @@ class SolidityGenerator implements Visitor<string, Context | undefined> {
     return this.visitFallbackEntry({
       node: { type: "fallback", stateMutability: "payable" },
     });
-   }
+ }
 
 
   visitEventEntry({node: entry, context}: Visit<Abi.EventEntry>): string {
@@ -259,6 +259,29 @@ class SolidityGenerator implements Visitor<string, Context | undefined> {
       ),
       `)`,
       `${anonymous ? "anonymous" : ""};`,
+    ].join(" ");
+  }
+
+  visitErrorEntry({node: entry, context}: Visit<Abi.ErrorEntry>): string {
+    if (this.versionFeatures["custom-errors"] !== true) {
+      throw new Error("ABI defines custom errors; use Solidity v0.8.4 or higher");
+    }
+
+    const {name, inputs} = entry;
+
+    return [
+      `error ${name}(`,
+      inputs.map((node) =>
+        dispatch({
+          node,
+          visitor: this,
+          context: {
+            ...context,
+            parameterModifiers: (parameter: Abi.Parameter) => []
+          },
+        })
+      ),
+      `);`,
     ].join(" ");
   }
 

--- a/packages/abi-to-sol/src/version-features.ts
+++ b/packages/abi-to-sol/src/version-features.ts
@@ -28,6 +28,10 @@ export const allFeatures = {
     ">=0.5.0": true,
     "<0.5.0": false
   },
+  "custom-errors": {
+    ">=0.8.4": true,
+    "<0.8.4": false
+  },
 } as const;
 
 export type AllFeatures = typeof allFeatures;

--- a/packages/abi-to-sol/src/visitor.ts
+++ b/packages/abi-to-sol/src/visitor.ts
@@ -13,6 +13,7 @@ export interface Visitor<T, C = undefined> {
   visitFallbackEntry(options: VisitOptions<Abi.FallbackEntry, C>): T;
   visitReceiveEntry(options: VisitOptions<Abi.ReceiveEntry, C>): T;
   visitEventEntry(options: VisitOptions<Abi.EventEntry, C>): T;
+  visitErrorEntry(options: VisitOptions<Abi.ErrorEntry, C>): T;
   visitParameter(options: VisitOptions<Abi.Parameter, C>): T;
 }
 
@@ -55,6 +56,8 @@ export const dispatch = <T, C>(options: DispatchOptions<T, C>): T => {
         return visitor.visitReceiveEntry({node, context});
       case "event":
         return visitor.visitEventEntry({node, context});
+      case "error":
+        return visitor.visitErrorEntry({node, context});
     }
   }
 
@@ -67,7 +70,7 @@ const isAbi = (node: Node | SchemaAbi): node is Abi.Abi | SchemaAbi =>
 const isEntry = (node: Node): node is Abi.Entry =>
   typeof node === "object" &&
   "type" in node &&
-  ["function", "constructor", "fallback", "receive", "event"].includes(
+  ["function", "constructor", "fallback", "receive", "event", "error"].includes(
     node.type
   ) &&
   (node.type !== "function" || "stateMutability" in node || "constant" in node);

--- a/packages/abi-to-sol/test/preflight.ts
+++ b/packages/abi-to-sol/test/preflight.ts
@@ -57,6 +57,14 @@ class FunctionParameterExcluder implements Visitor<boolean> {
       .reduce((a, b) => a && b, true);
   }
 
+  visitErrorEntry({node: entry}: VisitOptions<Abi.ErrorEntry>): boolean {
+    const {inputs} = entry;
+
+    return inputs
+      .map((node) => dispatch({node, visitor: this}))
+      .reduce((a, b) => a && b, true);
+  }
+
   visitParameter({node: parameter}: VisitOptions<Abi.Parameter>): boolean {
     if (parameter.type.startsWith("function")) {
       return false;

--- a/packages/web-ui/src/solidity/OptionsControls.tsx
+++ b/packages/web-ui/src/solidity/OptionsControls.tsx
@@ -62,7 +62,7 @@ export const OptionsControls = () => {
             setSolidityVersion(event.target.value)
           }}
         >
-          <option value="^0.8.0">^0.8.0</option>
+          <option value="^0.8.4">^0.8.4</option>
           <option value="^0.7.0">^0.7.0</option>
           <option value="^0.6.0">^0.6.0</option>
           <option value="^0.5.0">^0.5.0</option>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13931,10 +13931,10 @@ socks@^2.3.3:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
 
-solc@^0.7.2:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.7.6.tgz#21fc5dc11b85fcc518c181578b454f3271c27252"
-  integrity sha512-WsR/W7CXwh2VnmZapB4JrsDeLlshoKBz5Pz/zYNulB6LBsOEHI2Zj/GeKLMFcvv57OHiXHvxq5ZOQB+EdqxlxQ==
+solc@^0.8.6:
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.6.tgz#e4341fa6780137df97b94a0cfbd59b3f2037d0e0"
+  integrity sha512-miiDaWdaUnD7A6Cktb/2ug9f+ajcOCDYRr7vgbPEsMoutSlBtp5rca57oMg8iHSuM7jilwdxePujWI/+rbNftQ==
   dependencies:
     command-exists "^1.2.8"
     commander "3.0.2"


### PR DESCRIPTION
- Upgrade solc devDep to ^0.8.6 (for tests)
- Remove filter in tests that prevents generating arbitrary ABIs with custom errors
- Switch ^0.8.0 option in web-ui dropdown to be ^0.8.4 instead
- Add `visitError()` to Visitor pattern
- Add `custom-errors` version feature and check for version compatibility when `visitError()` is invoked
- Implement custom error code generation