### PR TITLE
Update to Node.js LTS

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # abi-to-sol changelog
 
-## v0.5.3
+## vNext
+
+### Internal improvements
+
+- Update to Node.js LTS ([#63](https://github.com/gnidan/abi-to-sol/pull/63) by
+  [@gnidan](https://github.com/gnidan))
 
 ### Dependency updates
 


### PR DESCRIPTION
Node v12 ends support after today. This PR updates CI to reflect current LTS versions of Node.