### PR TITLE
Add version feature knowledge for user-defined value types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Update copyright notice ([#64](https://github.com/gnidan/abi-to-sol/pull/64)
   by [@gnidan](https://github.com/gnidan))
 
+- Add version feature knowledge for user-defined value types
+  ([#65](https://github.com/gnidan/abi-to-sol/pull/65) by
+  [@gnidan](https://github.com/gnidan))
+
 ### Dependency updates
 
 - Bump follow-redirects from 1.14.1 to 1.14.7

--- a/packages/abi-to-sol/src/version-features.ts
+++ b/packages/abi-to-sol/src/version-features.ts
@@ -32,6 +32,10 @@ export const allFeatures = {
     ">=0.8.4": true,
     "<0.8.4": false
   },
+  "user-defined-value-types": {
+    ">=0.8.8": true,
+    "<0.8.8": false
+  }
 } as const;
 
 export type AllFeatures = typeof allFeatures;


### PR DESCRIPTION
Even though abi-to-sol currently does not support generating these in output.