### PR TITLE
Produce valid syntax for function type params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+### Bug fixes
+
+- Produce valid syntax for function type params
+  ([#77](https://github.com/gnidan/abi-to-sol/pull/77) by
+  [@gnidan](https://github.com/gnidan))
+
 ### Dependency updates
 
 - Bump parse-url from 6.0.0 to 6.0.2

--- a/packages/abi-to-sol/src/solidity.ts
+++ b/packages/abi-to-sol/src/solidity.ts
@@ -417,7 +417,7 @@ class SolidityGenerator implements Visitor<string, Context | undefined> {
     const signature = this.generateSignature(variable);
 
     if (!signature) {
-      return variable.type;
+      return this.generateElementaryType(variable, context);
     }
 
     const { type } = variable;
@@ -434,6 +434,29 @@ class SolidityGenerator implements Visitor<string, Context | undefined> {
 
     return type.replace("tuple", identifier);
   }
+
+  private generateElementaryType(
+    variable: Abi.Parameter | Component,
+    context: Pick<Context, "interfaceName"> = {}
+  ): string {
+    // normally we can return the type itself, but functions are a special case
+    if (variable.type !== "function") {
+      return variable.type;
+    }
+
+    // use just the `internalType` field if it exists
+    if ("internalType" in variable && variable.internalType) {
+      return variable.internalType;
+    }
+
+    // otherwise output minimally syntactically-valid syntax with a warning
+    return [
+      "/* warning: the following type may be incomplete. ",
+      "the receiving contract may expect additional input or output parameters. */ ",
+      "function() external"
+    ].join("");
+  }
+
 
   private generateSignature(
     variable: Abi.Parameter | Component


### PR DESCRIPTION
Addresses #76, originally raised by @esaulpaugh.

This PR ensures the resulting Solidity output for function type parameters will always be valid.

In cases where the `internalType` field is provided, this change uses that field directly for best results. Since that field is not part of the ABI JSON spec, then in cases where it's not provided, this PR falls back to behavior of specifying the minimally-valid `function() external` type alongside a warning.

<details>
<summary>Example missing `internalType` fallback output</summary>

```solidity
// SPDX-License-Identifier: UNLICENSED
// !! THIS FILE WAS AUTOGENERATED BY abi-to-sol v0.6.2. SEE SOURCE BELOW. !!
pragma solidity >=0.7.0 <0.9.0;

interface MyInterface {
    function map(
        /* warning: the following type may be incomplete. the receiving contract may expect additional input or output parameters. */
        function() f,
        uint256[] memory list
    ) external pure returns (uint256[] memory);
}

// THIS FILE WAS AUTOGENERATED FROM THE FOLLOWING ABI JSON:
/*
[{"inputs":[{"name":"f","type":"function"},{"internalType":"uint256[]","name":"list","type":"uint256[]"}],"name":"map","outputs":[{"internalType":"uint256[]","name":"","type":"uint256[]"}],"stateMutability":"pure","type":"function"}]
*/
```

</details>