### PR TITLE
Update README to remove npx support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## vNext
 
-See [release notes](https://github.com/gnidan/abi-to-sol/releases/tag/v0.6.4).
+### Project updates
+
+- Update README to remove npx support
+  ([#83](https://github.com/gnidan/abi-to-sol/pull/83) by
+  [@gnidan](https://github.com/gnidan))
 
 ## v0.6.4
+
+See [release notes](https://github.com/gnidan/abi-to-sol/releases/tag/v0.6.4).
 
 ### Dependency updates
 

--- a/packages/abi-to-sol/README.md
+++ b/packages/abi-to-sol/README.md
@@ -12,14 +12,14 @@ Skip the terminal and just use the hosted
 
 ## CLI instructions
 
-No need to install - just use [npx](https://www.npmjs.com/package/npx) (e.g.
-`npx abi-to-sol`).
-
-Alternatively, install globally via:
+Install globally via:
 
 ```console
 $ npm install -g abi-to-sol
 ```
+
+Installing locally should work fine as well, but you may have to jump through
+hoops to get the `abi-to-sol` script available on your PATH.
 
 ### Usage
 
@@ -103,4 +103,6 @@ interface ENS {
 
 ## Is this project useful to you?
 
-Feel free to donate to [gnidan.eth](https://etherscan.io/address/0xefef50ebacd8da3c13932ac204361b704eb8292c) ❤️
+Feel free to donate to
+[gnidan.eth](https://etherscan.io/address/0xefef50ebacd8da3c13932ac204361b704eb8292c)
+❤️


### PR DESCRIPTION
Using `npx abi-to-sol` without prior installation now appears to fail to invoke prettier correctly, as described by @gosuto-inzasheru in #67.

After trouble finding a quick way to fix this, this PR instead simply removes support for this interface, since the web UI suffices as a quickstart instead. Installing and running abi-to-sol does not seem to have these same problems, even with `npx abi-to-sol` after installation.